### PR TITLE
[F] Update Iris version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,15 +5,17 @@
   "requires": true,
   "dependencies": {
     "@repositive/iris": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/@repositive/iris/-/iris-0.7.7.tgz",
-      "integrity": "sha1-ZftIx1eHcZB8wvt+UyUN8siXcpg=",
+      "version": "1.0.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@repositive/iris/-/iris-1.0.0-alpha.8.tgz",
+      "integrity": "sha512-PE0ySV5L0/ZvOveeRqdY15nPHSaX4Kn1fIHMqArSFhBL15NTQn32ERMVyhyTOnT/xyqhzsmv9Sh+WPJ5c2oOPw==",
       "requires": {
         "@types/amqplib": "0.5.3",
         "@types/ramda": "0.24.0",
         "amqplib": "0.5.1",
         "bluebird": "3.5.0",
+        "funfix": "6.2.2",
         "ramda": "0.24.1",
+        "rxjs": "5.5.6",
         "uuid": "3.1.0",
         "yargs": "8.0.2"
       },
@@ -44,14 +46,14 @@
       "resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.5.3.tgz",
       "integrity": "sha512-GC4S81SH19YDhPVbjkYfccsyRmmQzeRJPzuqoQX5U7ssLpft70E4Cqy9R+oKH6EkGC4Mfl6v1PD3WXknIThwsQ==",
       "requires": {
-        "@types/bluebird": "3.5.8",
+        "@types/bluebird": "3.5.20",
         "@types/node": "8.0.19"
       }
     },
     "@types/bluebird": {
-      "version": "3.5.8",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.8.tgz",
-      "integrity": "sha512-rBfrD56OxaqVjghtVqp2EEX0ieHkRk6IefDVrQXIVGvlhDOEBTvZff4Q02uo84ukVkH4k5eB1cPKGDM2NlFL8A=="
+      "version": "3.5.20",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.20.tgz",
+      "integrity": "sha512-Wk41MVdF+cHBfVXj/ufUHJeO3BlIQr1McbHZANErMykaCWeDSZbH5erGjNBw2/3UlRdSxZbLfSuQTzFmPOYFsA=="
     },
     "@types/config": {
       "version": "0.0.32",
@@ -390,9 +392,9 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "requires": {
-        "lru-cache": "4.1.1",
+        "lru-cache": "4.1.3",
         "shebang-command": "1.2.0",
-        "which": "1.3.0"
+        "which": "1.3.1"
       }
     },
     "csv-parse": {
@@ -1598,6 +1600,49 @@
       "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
       "dev": true
     },
+    "funfix": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/funfix/-/funfix-6.2.2.tgz",
+      "integrity": "sha1-4TrQMjJiOeys2Jw7GyFhppyPWhs=",
+      "requires": {
+        "funfix-core": "6.2.2",
+        "funfix-effect": "6.2.2",
+        "funfix-exec": "6.2.2",
+        "funfix-types": "6.2.2"
+      }
+    },
+    "funfix-core": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/funfix-core/-/funfix-core-6.2.2.tgz",
+      "integrity": "sha1-UOrNwqWpTCuopX2SbRonWrfrvBk="
+    },
+    "funfix-effect": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/funfix-effect/-/funfix-effect-6.2.2.tgz",
+      "integrity": "sha1-diua+XzBUbqIKQ9b+iefQ0TiZkE=",
+      "requires": {
+        "funfix-core": "6.2.2",
+        "funfix-exec": "6.2.2"
+      }
+    },
+    "funfix-exec": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/funfix-exec/-/funfix-exec-6.2.2.tgz",
+      "integrity": "sha1-D/A+7Lam6YOQgN3vTSQBX2g/zWU=",
+      "requires": {
+        "funfix-core": "6.2.2"
+      }
+    },
+    "funfix-types": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/funfix-types/-/funfix-types-6.2.2.tgz",
+      "integrity": "sha1-JXfk+xO77b595Ddmv839P0MwRCI=",
+      "requires": {
+        "funfix-core": "6.2.2",
+        "funfix-effect": "6.2.2",
+        "funfix-exec": "6.2.2"
+      }
+    },
     "get-caller-file": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
@@ -1691,9 +1736,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
     },
     "husky": {
       "version": "0.14.3",
@@ -2115,9 +2160,9 @@
       "dev": true
     },
     "lru-cache": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "requires": {
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
@@ -2134,7 +2179,7 @@
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "requires": {
-        "mimic-fn": "1.1.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "merge-descriptors": {
@@ -2176,9 +2221,9 @@
       }
     },
     "mimic-fn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -2270,10 +2315,10 @@
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "requires": {
-        "hosted-git-info": "2.5.0",
+        "hosted-git-info": "2.6.0",
         "is-builtin-module": "1.0.0",
         "semver": "5.4.1",
-        "validate-npm-package-license": "3.0.1"
+        "validate-npm-package-license": "3.0.3"
       }
     },
     "normalize-path": {
@@ -3990,17 +4035,25 @@
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "requires": {
+        "p-try": "1.0.0"
+      }
     },
     "p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "requires": {
-        "p-limit": "1.1.0"
+        "p-limit": "1.3.0"
       }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
     },
     "package-json": {
       "version": "1.2.0",
@@ -4373,6 +4426,14 @@
         "through": "2.3.8"
       }
     },
+    "rxjs": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.6.tgz",
+      "integrity": "sha512-v4Q5HDC0FHAQ7zcBX7T2IL6O5ltl1a2GX4ENjPXg6SjDY69Cmx9v4113C99a4wGF16ClPv5Z8mghuYorVkg/kg==",
+      "requires": {
+        "symbol-observable": "1.0.1"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
@@ -4451,22 +4512,32 @@
       "dev": true
     },
     "spdx-correct": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+      "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
+    "spdx-exceptions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+    },
     "spdx-expression-parse": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "requires": {
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.0"
+      }
     },
     "spdx-license-ids": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
     },
     "split": {
       "version": "0.3.3",
@@ -4585,6 +4656,11 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
+    },
+    "symbol-observable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
     },
     "tap-out": {
       "version": "1.4.2",
@@ -4805,18 +4881,18 @@
       "dev": true
     },
     "validate-npm-package-license": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+      "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "which": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "requires": {
         "isexe": "2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "service"
   ],
   "dependencies": {
-    "@repositive/iris": "^0.7.7",
+    "@repositive/iris": "^1.0.0-alpha.8",
     "config": "^1.26.1",
     "csv-parse": "^1.2.1",
     "ramda": "^0.24.1"

--- a/src/service.spec.ts
+++ b/src/service.spec.ts
@@ -7,16 +7,15 @@ test('Testing basic service', (t: Test) => {
   async function _test() {
 
     const _pack = { name: 'nidaba', version: '1' };
-    const _iris = { request: stub() as any, register: stub().returns(Promise.resolve()) as any };
-    const _irisSetup = stub().returns(Promise.resolve(_iris));
+    const _irisBackend = { request: stub() as any, register: stub().returns(Promise.resolve()) as any };
+    const _iris = { request: stub() as any, register: stub().returns(Promise.resolve()) as any, backend: _irisBackend };
+    const _irisSetup = stub().returns({map: stub().callsArgWith(0, _iris)});
     const irisConfig = { url: 'a', exchange: 'b', namespace: 'nidaba' };
     const _config = { get: stub().returns(irisConfig) } as any;
-    const _irisBackend = { register: stub().returns(Promise.resolve()) as any };
-    const _irisAMQP = stub().returns(Promise.resolve(_irisBackend));
 
     t.equals(typeof init, 'function', 'Service exports a function');
 
-    const setupResult = init({ _pack, _irisSetup, _irisAMQP, _config });
+    const setupResult = init({ _pack, _irisSetup, _config });
 
     t.ok(setupResult instanceof Promise, 'Service setup must return a promise');
 
@@ -24,7 +23,8 @@ test('Testing basic service', (t: Test) => {
       .then(() => {
         t.ok(true, 'Yeah, service setup does not blow up');
       })
-      .catch(() => {
+      .catch((err) => {
+        console.error(err);
         t.notOk(true, 'Setup should not blow up at this point');
       });
 


### PR DESCRIPTION
Nidaba blows up during the local environment setup because it runs before rabbitmq starts listening for connections.

This PR updates nidaba to the latest version of Iris, solving the previous error and improving its logging capabilities.